### PR TITLE
test: add minimum pytest suite for domain, strategies, and API

### DIFF
--- a/requirements-api.txt
+++ b/requirements-api.txt
@@ -6,3 +6,5 @@ pydantic>=2.5.0
 pydantic-settings>=2.0.0
 email-validator>=2.0.0
 python-multipart>=0.0.6
+pytest>=8.0.0
+httpx>=0.27.0

--- a/tests/test_api_endpoints.py
+++ b/tests/test_api_endpoints.py
@@ -1,0 +1,89 @@
+from decimal import Decimal
+from uuid import UUID
+
+from fastapi.testclient import TestClient
+
+from app.application.api import app
+from app.application.api import get_facade
+from app.domain.models import Currency
+from app.domain.models import Transaction
+from app.domain.models import TransactionStatus
+from app.domain.models import TransactionType
+
+
+class FakeFacade:
+    def deposit(self, account_id: UUID, amount: Decimal, description: str | None = None) -> Transaction:
+        return Transaction(
+            type=TransactionType.DEPOSIT,
+            amount=amount,
+            currency=Currency.USD,
+            to_account_id=account_id,
+            status=TransactionStatus.APPROVED,
+            fee=Decimal("0.00"),
+            description=description,
+        )
+
+    def transfer(
+        self,
+        from_account_id: UUID,
+        to_account_id: UUID,
+        amount: Decimal,
+        description: str | None = None,
+    ) -> Transaction:
+        return Transaction(
+            type=TransactionType.TRANSFER,
+            amount=amount,
+            currency=Currency.USD,
+            from_account_id=from_account_id,
+            to_account_id=to_account_id,
+            status=TransactionStatus.APPROVED,
+            fee=Decimal("0.00"),
+            description=description,
+        )
+
+
+def test_deposit_happy_path(monkeypatch) -> None:
+    monkeypatch.setattr("app.application.api.create_tables", lambda: None)
+    app.dependency_overrides[get_facade] = lambda: FakeFacade()
+
+    with TestClient(app) as client:
+        response = client.post(
+            "/transactions/deposit",
+            json={
+                "account_id": "123e4567-e89b-12d3-a456-426614174000",
+                "amount": "100.00",
+                "description": "Initial deposit",
+            },
+        )
+
+    app.dependency_overrides.clear()
+
+    assert response.status_code == 201
+    payload = response.json()
+    assert payload["type"] == "DEPOSIT"
+    assert payload["status"] == "APPROVED"
+    assert payload["amount"] == "100.00"
+
+
+def test_transfer_happy_path(monkeypatch) -> None:
+    monkeypatch.setattr("app.application.api.create_tables", lambda: None)
+    app.dependency_overrides[get_facade] = lambda: FakeFacade()
+
+    with TestClient(app) as client:
+        response = client.post(
+            "/transactions/transfer",
+            json={
+                "from_account_id": "123e4567-e89b-12d3-a456-426614174000",
+                "to_account_id": "987e6543-e21b-12d3-a456-426614174999",
+                "amount": "25.00",
+                "description": "Transfer test",
+            },
+        )
+
+    app.dependency_overrides.clear()
+
+    assert response.status_code == 201
+    payload = response.json()
+    assert payload["type"] == "TRANSFER"
+    assert payload["status"] == "APPROVED"
+    assert payload["amount"] == "25.00"

--- a/tests/test_domain_models.py
+++ b/tests/test_domain_models.py
@@ -1,0 +1,24 @@
+from decimal import Decimal
+from uuid import uuid4
+
+import pytest
+
+from app.domain.models import Account
+from app.domain.models import AccountFrozenError
+from app.domain.models import AccountStatus
+from app.domain.models import InsufficientFundsError
+
+
+def test_account_debit_raises_insufficient_funds() -> None:
+    account = Account(customer_id=uuid4(), balance=Decimal("50.00"))
+
+    with pytest.raises(InsufficientFundsError):
+        account.debit(Decimal("100.00"))
+
+
+def test_account_debit_rejected_when_account_frozen() -> None:
+    account = Account(customer_id=uuid4(), balance=Decimal("100.00"))
+    account.status = AccountStatus.FROZEN
+
+    with pytest.raises(AccountFrozenError):
+        account.debit(Decimal("10.00"))

--- a/tests/test_strategies.py
+++ b/tests/test_strategies.py
@@ -1,0 +1,27 @@
+from decimal import Decimal
+from uuid import uuid4
+
+from app.domain.rules import MaxAmountRule
+from app.domain.rules import PercentFeeStrategy
+
+
+def test_percent_fee_strategy_calculates_expected_fee() -> None:
+    strategy = PercentFeeStrategy(Decimal("1.5"))
+
+    fee = strategy.calculate_fee(Decimal("200.00"))
+
+    assert fee == Decimal("3.00")
+
+
+def test_max_amount_rule_rejects_amount_over_limit() -> None:
+    rule = MaxAmountRule(Decimal("100.00"))
+
+    result = rule.check(
+        amount=Decimal("150.00"),
+        account_id=uuid4(),
+        transaction_type="DEPOSIT",
+        get_recent_transactions=lambda *_: [],
+    )
+
+    assert result.passed is False
+    assert "límite máximo" in (result.reason or "")


### PR DESCRIPTION
﻿## Summary

Implements the minimum required pytest suite for grading (issue #11), covering domain rules, strategy behavior, and API happy paths.

## Related Issue

Closes #11

## What Changed

- Added 2 domain tests:
  - Insufficient funds rejection on account debit.
  - Account status validation (frozen account cannot be debited).
- Added 2 strategy tests:
  - Percentage fee calculation.
  - Risk rejection using max amount rule.
- Added 2 API tests (happy path):
  - POST /transactions/deposit
  - POST /transactions/transfer
- Added test dependencies in API requirements:
  - pytest
  - httpx

## Validation

Executed:

`ash
python -m pytest -q
`

## Result

- ✅ 6 passed
- ❌ 0 failed
- ⚠️ Deprecation warnings only (non-blocking for this issue)

## Checklist

- [x] 2 domain tests implemented
- [x] 2 strategy tests implemented
- [x] 2 API tests implemented
- [x] Full test suite passes
- [x] Scope limited to issue #11 requirements
